### PR TITLE
Create query builder from a struct and named queries

### DIFF
--- a/query_builder.go
+++ b/query_builder.go
@@ -189,6 +189,18 @@ func (q *QueryBuilder) Update() string {
 	return fmt.Sprintf("UPDATE %s SET %s WHERE id = $%d", q.Table, join(v), pos)
 }
 
+// NamedUpdate returns the query to update a record using named values. Update
+// won't update neither the id nor the created_at column.
+func (q *QueryBuilder) NamedUpdate() string {
+	var values []string
+	for _, name := range q.Columns {
+		if name != idColumn && name != createdAtColumn {
+			values = append(values, name+" = :"+name)
+		}
+	}
+	return fmt.Sprintf("UPDATE %s SET %s WHERE id = :id", q.Table, join(values))
+}
+
 // Delete returns the query to mark a record as deleted.
 func (q *QueryBuilder) Delete() string {
 	return fmt.Sprintf("UPDATE %s SET deleted_at = $1 WHERE id = $2", q.Table)

--- a/query_builder.go
+++ b/query_builder.go
@@ -35,8 +35,8 @@ func defaultOptions() *options {
 // Option is the type used to pass options to the New and Must functions.
 type Option func(o *options)
 
-// WithTableName sets the table name to use.
-func WithTableName(name string) Option {
+// TableName sets the table name to use.
+func TableName(name string) Option {
 	return func(o *options) {
 		if name != "" {
 			o.tableName = name
@@ -44,9 +44,9 @@ func WithTableName(name string) Option {
 	}
 }
 
-// WithTableTag sets the tag key used to get the table name. It defaults to
+// TableTag sets the tag key used to get the table name. It defaults to
 // "dbtable".
-func WithTableTag(key string) Option {
+func TableTag(key string) Option {
 	return func(o *options) {
 		if key != "" {
 			o.tableTag = key
@@ -54,7 +54,7 @@ func WithTableTag(key string) Option {
 	}
 }
 
-// WithColumnTag sets the tag key used to get a column name. It defaults to
+// ColumnTag sets the tag key used to get a column name. It defaults to
 // "db".
 func WithColumnTag(key string) Option {
 	return func(o *options) {
@@ -67,7 +67,7 @@ func WithColumnTag(key string) Option {
 // New returns a new query builder configured with the fields tags in the given
 // struct. By default it uses the tag "dbtable" for the table name and "db" for
 // the column names.
-func New(i interface{}, opts ...Option) (*QueryBuilder, error) {
+func New(i any, opts ...Option) (*QueryBuilder, error) {
 	o := defaultOptions()
 	for _, fn := range opts {
 		fn(o)
@@ -84,7 +84,7 @@ func New(i interface{}, opts ...Option) (*QueryBuilder, error) {
 // the column names.
 //
 // Must will panic if i is not an struct.
-func Must(i interface{}, opts ...Option) *QueryBuilder {
+func Must(i any, opts ...Option) *QueryBuilder {
 	qb, err := New(i, opts...)
 	if err != nil {
 		panic(err)

--- a/query_builder_test.go
+++ b/query_builder_test.go
@@ -55,7 +55,7 @@ func TestNew(t *testing.T) {
 	s := "string"
 
 	type args struct {
-		i    interface{}
+		i    any
 		opts []Option
 	}
 	tests := []struct {
@@ -89,12 +89,12 @@ func TestNew(t *testing.T) {
 			Columns:       []string{"id", "created_at", "deleted_at", "name", "email"},
 			SelectDeleted: false,
 		}, false},
-		{"ok with table name", args{&testTable{}, []Option{WithTableName("mytable")}}, &QueryBuilder{
+		{"ok with table name", args{&testTable{}, []Option{TableName("mytable")}}, &QueryBuilder{
 			Table:         "mytable",
 			Columns:       []string{"id", "name", "email"},
 			SelectDeleted: false,
 		}, false},
-		{"ok with options", args{testTable{}, []Option{WithTableTag("table"), WithColumnTag("col")}}, &QueryBuilder{
+		{"ok with options", args{testTable{}, []Option{TableTag("table"), WithColumnTag("col")}}, &QueryBuilder{
 			Table:         "foo",
 			Columns:       []string{"foo_id", "foo_name", "foo_email"},
 			SelectDeleted: false,
@@ -111,45 +111,16 @@ func TestNew(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("New() = %v, want %v", got, tt.want)
 			}
-		})
-	}
-}
 
-func TestMust(t *testing.T) {
-	type args struct {
-		i    interface{}
-		opts []Option
-	}
-	tests := []struct {
-		name      string
-		args      args
-		want      *QueryBuilder
-		wantPanic bool
-	}{
-		{"ok", args{testTable{}, nil}, &QueryBuilder{
-			Table:         "users",
-			Columns:       []string{"id", "name", "email"},
-			SelectDeleted: false,
-		}, false},
-		{"ok with options", args{testTable{}, []Option{WithTableName("foo"), WithTableTag("table"), WithColumnTag("col")}}, &QueryBuilder{
-			Table:         "foo",
-			Columns:       []string{"foo_id", "foo_name", "foo_email"},
-			SelectDeleted: false,
-		}, false},
-		{"fail", args{"not a struct", nil}, nil, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
 				r := recover()
-				if r != nil != tt.wantPanic {
-					t.Errorf("Must() panic = %v, wantErr %v", r, tt.wantPanic)
+				if r != nil != tt.wantErr {
+					t.Errorf("Must() panic = %v, wantErr %v", r, tt.wantErr)
 				}
 			}()
-
-			got := Must(tt.args.i, tt.args.opts...)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("New() = %v, want %v", got, tt.want)
+			gotMust := Must(tt.args.i, tt.args.opts...)
+			if !reflect.DeepEqual(gotMust, tt.want) {
+				t.Errorf("Must() = %v, want %v", gotMust, tt.want)
 			}
 		})
 	}

--- a/query_builder_test.go
+++ b/query_builder_test.go
@@ -326,7 +326,7 @@ func TestQueryBuilder_NamedInsert(t *testing.T) {
 		fields fields
 		want   string
 	}{
-		{"ok", fields{"users", []string{"id", "name", "email"}, false}, "INSERT INTO users (id, name, email) VALUES (:id, :name, :email)"},
+		{"ok", fields{"users", []string{"id", "name", "email", "created_at", "deleted_at"}, false}, "INSERT INTO users (id, name, email, created_at, deleted_at) VALUES (:id, :name, :email, :created_at, :deleted_at)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -353,7 +353,7 @@ func TestQueryBuilder_NamedInsertWithReturning(t *testing.T) {
 		fields fields
 		want   string
 	}{
-		{"ok", fields{"users", []string{"id", "name", "email"}, false}, "INSERT INTO users (name, email) VALUES (:name, :email) RETURNING id"},
+		{"ok", fields{"users", []string{"id", "name", "email", "created_at", "deleted_at"}, false}, "INSERT INTO users (name, email, created_at, deleted_at) VALUES (:name, :email, :created_at, :deleted_at) RETURNING id"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -364,6 +364,33 @@ func TestQueryBuilder_NamedInsertWithReturning(t *testing.T) {
 			}
 			if got := q.NamedInsertWithReturning(); got != tt.want {
 				t.Errorf("QueryBuilder.NamedInsertWithReturning() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryBuilder_NamedUpdate(t *testing.T) {
+	type fields struct {
+		Table         string
+		Columns       []string
+		SelectDeleted bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{"ok", fields{"users", []string{"id", "name", "email", "created_at", "deleted_at"}, false}, "UPDATE users SET name = :name, email = :email, deleted_at = :deleted_at WHERE id = :id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := &QueryBuilder{
+				Table:         tt.fields.Table,
+				Columns:       tt.fields.Columns,
+				SelectDeleted: tt.fields.SelectDeleted,
+			}
+			if got := q.NamedUpdate(); got != tt.want {
+				t.Errorf("QueryBuilder.NamedUpdate() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/table.go
+++ b/table.go
@@ -25,7 +25,7 @@ func getTableName(name string) string {
 	b := new(strings.Builder)
 	for i, r := range name {
 		if unicode.IsUpper(r) && i != 0 {
-			b.WriteRune('_')
+			b.WriteByte('_')
 		}
 		b.WriteRune(unicode.ToLower(r))
 	}

--- a/table.go
+++ b/table.go
@@ -22,7 +22,7 @@ func getTagValue(key string, f reflect.StructField) string {
 }
 
 func getTableName(name string) string {
-	b := new(strings.Builder)
+	var b strings.Builder
 	for i, r := range name {
 		if unicode.IsUpper(r) && i != 0 {
 			b.WriteByte('_')
@@ -32,7 +32,7 @@ func getTableName(name string) string {
 	return b.String()
 }
 
-func structOf(i interface{}) (reflect.Value, error) {
+func structOf(i any) (reflect.Value, error) {
 	v := reflect.ValueOf(i)
 	switch v.Kind() {
 	case reflect.Struct:
@@ -44,7 +44,7 @@ func structOf(i interface{}) (reflect.Value, error) {
 		}
 	}
 
-	return reflect.Value{}, fmt.Errorf("type %T is not an a struct", i)
+	return reflect.Value{}, fmt.Errorf("%T is neither struct nor does it point to one", i)
 }
 
 func fieldColumns(f reflect.StructField, o *options) []string {
@@ -76,7 +76,7 @@ func fieldColumns(f reflect.StructField, o *options) []string {
 	return columns
 }
 
-func getTable(i interface{}, o *options) (table, error) {
+func getTable(i any, o *options) (table, error) {
 	v, err := structOf(i)
 	if err != nil {
 		return table{}, err

--- a/table.go
+++ b/table.go
@@ -1,0 +1,112 @@
+package qb
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+type table struct {
+	Name    string
+	Columns []string
+}
+
+func getTagValue(key string, f reflect.StructField) string {
+	s := f.Tag.Get(key)
+	if s == "" || s == "-" {
+		return ""
+	}
+	parts := strings.SplitN(s, ",", 2)
+	return strings.TrimSpace(parts[0])
+}
+
+func getTableName(name string) string {
+	b := new(strings.Builder)
+	for i, r := range name {
+		if unicode.IsUpper(r) && i != 0 {
+			b.WriteRune('_')
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+func structOf(i interface{}) (reflect.Value, error) {
+	v := reflect.ValueOf(i)
+	switch v.Kind() {
+	case reflect.Struct:
+		return v, nil
+	case reflect.Ptr, reflect.Interface:
+		elem := v.Elem()
+		if elem.Kind() == reflect.Struct {
+			return elem, nil
+		}
+	}
+
+	return reflect.Value{}, fmt.Errorf("type %T is not an a struct", i)
+}
+
+func fieldColumns(f reflect.StructField, o *options) []string {
+	var typ reflect.Type
+	switch f.Type.Kind() {
+	case reflect.Struct:
+		typ = f.Type
+	case reflect.Ptr:
+		typ = f.Type.Elem()
+		if typ.Kind() != reflect.Struct {
+			return nil
+		}
+	default:
+		return nil
+	}
+
+	var columns []string
+	for i, n := 0, typ.NumField(); i < n; i++ {
+		field := typ.Field(i)
+
+		cols := fieldColumns(field, o)
+		columns = append(columns, cols...)
+
+		// Get the columns
+		if name := getTagValue(o.columnTag, field); name != "" {
+			columns = append(columns, name)
+		}
+	}
+	return columns
+}
+
+func getTable(i interface{}, o *options) (table, error) {
+	v, err := structOf(i)
+	if err != nil {
+		return table{}, err
+	}
+
+	t := table{Name: o.tableName}
+	typ := v.Type()
+	for i, n := 0, typ.NumField(); i < n; i++ {
+		field := typ.Field(i)
+
+		// Get table if available
+		if t.Name == "" {
+			if name := getTagValue(o.tableTag, field); name != "" {
+				t.Name = name
+			}
+		}
+
+		// Resolve columns recursively
+		cols := fieldColumns(field, o)
+		t.Columns = append(t.Columns, cols...)
+
+		// Get the columns
+		if name := getTagValue(o.columnTag, field); name != "" {
+			t.Columns = append(t.Columns, name)
+		}
+	}
+
+	if t.Name == "" {
+		t.Name = getTableName(typ.Name())
+	}
+
+	return t, nil
+}


### PR DESCRIPTION
### Description

This commit allows to create query builders from a struct using the `dbtable` and `db` tags, they are also configurable. This commit also adds support for named queries compatible with [jmoiron/sqlx](https://pkg.go.dev/github.com/jmoiron/sqlx).