### PR TITLE
Add support for different bind parameters

### DIFF
--- a/query_builder.go
+++ b/query_builder.go
@@ -12,24 +12,41 @@ const (
 	deletedAtColumn = "deleted_at"
 )
 
+// BindParam represents the binding parameter in SQL queries.
+type BindParam int
+
+const (
+	// Dollar is the binding parameter type used in PostgreSQL, these parameters
+	// use the character $ and number with the positional number starting in 1.
+	// They look like $1, $2, ...
+	DOLLAR BindParam = iota + 1
+	// QUESTION is the binding parameter type used in mysql and sqlite3, this
+	// parameters just the character ?.
+	QUESTION
+)
+
 // QueryBuilder provides a simple list of SQL queries that can be used by the
 // models. It requires tables with the columns id, created_at, and deleted_at.
 type QueryBuilder struct {
 	Table         string
 	Columns       []string
 	SelectDeleted bool
+	PrimaryKey    string
+	BindType      BindParam
 }
 
 type options struct {
 	tableName string
 	tableTag  string
 	columnTag string
+	bindType  BindParam
 }
 
 func defaultOptions() *options {
 	return &options{
 		tableTag:  "dbtable",
 		columnTag: "db",
+		bindType:  DOLLAR,
 	}
 }
 
@@ -57,12 +74,29 @@ func TableTag(key string) Option {
 
 // ColumnTag sets the tag key used to get a column name. It defaults to
 // "db".
-func WithColumnTag(key string) Option {
+func ColumnTag(key string) Option {
 	return func(o *options) {
 		if key != "" {
 			o.columnTag = key
 		}
 	}
+}
+
+// BindType defines the binding parameter type used. It defaults to DOLLAR.
+func BindType(t BindParam) Option {
+	return func(o *options) {
+		if t != 0 {
+			o.bindType = t
+		}
+	}
+}
+
+// WithColumnTag sets the tag key used to get a column name. It defaults to
+// "db".
+//
+// Deprecated: use ColumnTag.
+func WithColumnTag(key string) Option {
+	return ColumnTag(key)
 }
 
 // New returns a new query builder configured with the fields tags in the given
@@ -77,7 +111,14 @@ func New(i any, opts ...Option) (*QueryBuilder, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewQueryBuilder(t.Name, t.Columns), nil
+	qb := NewQueryBuilder(t.Name, t.Columns)
+	if t.PrimaryKey != "" {
+		qb.PrimaryKey = t.PrimaryKey
+	}
+	if o.bindType != 0 {
+		qb.BindType = o.bindType
+	}
+	return qb, nil
 }
 
 // Must returns a new query builder configured with the fields tags in the given
@@ -100,6 +141,8 @@ func NewQueryBuilder(table string, columns []string) *QueryBuilder {
 		Table:         table,
 		Columns:       columns,
 		SelectDeleted: false,
+		PrimaryKey:    idColumn,
+		BindType:      DOLLAR,
 	}
 }
 
@@ -111,7 +154,7 @@ func (q *QueryBuilder) Queries() (string, string, string, string) {
 
 // Select returns the query to get a record by id.
 func (q *QueryBuilder) Select() string {
-	s := fmt.Sprintf("SELECT %s FROM %s WHERE id = $1", q.columns(), q.Table)
+	s := fmt.Sprintf("SELECT %s FROM %s WHERE %s = %s", q.columns(), q.Table, q.idColumn(), q.bind(1))
 	if !q.SelectDeleted {
 		s += " AND deleted_at IS NULL"
 	}
@@ -120,10 +163,10 @@ func (q *QueryBuilder) Select() string {
 
 // SelectBy returns a query to get a record by the given column name.
 func (q *QueryBuilder) SelectBy(name string, extraNames ...string) string {
-	s := fmt.Sprintf("SELECT %s FROM %s WHERE %s = $1", q.columns(), q.Table, name)
+	s := fmt.Sprintf("SELECT %s FROM %s WHERE %s = %s", q.columns(), q.Table, name, q.bind(1))
 	// Append extra names.
 	for i, n := range extraNames {
-		s += fmt.Sprintf(" AND %s = $%d", n, i+2)
+		s += fmt.Sprintf(" AND %s = %s", n, q.bind(i+2))
 	}
 	if !q.SelectDeleted {
 		s += " AND deleted_at IS NULL"
@@ -147,15 +190,16 @@ func (q *QueryBuilder) Insert() string {
 // InsertWithReturning returns the query to insert that returns the id.
 func (q *QueryBuilder) InsertWithReturning() string {
 	var pos = 1
+	var idName = q.idColumn()
 	var columns, values []string
 	for _, name := range q.Columns {
-		if name != idColumn {
+		if name != idName {
 			columns = append(columns, name)
-			values = append(values, "$"+strconv.Itoa(pos))
+			values = append(values, q.bind(pos))
 			pos++
 		}
 	}
-	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) RETURNING id", q.Table, join(columns), join(values))
+	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) RETURNING %s", q.Table, join(columns), join(values), idName)
 }
 
 // Insert returns the query to insert a record using named values.
@@ -166,50 +210,69 @@ func (q *QueryBuilder) NamedInsert() string {
 // NamedInsertWithReturning returns the query to insert a record using named
 // values, the query will return the id.
 func (q *QueryBuilder) NamedInsertWithReturning() string {
+	var idName = q.idColumn()
 	var columns, values []string
 	for _, name := range q.Columns {
-		if name != idColumn {
+		if name != idName {
 			columns = append(columns, name)
 			values = append(values, ":"+name)
 		}
 	}
-	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) RETURNING id", q.Table, join(columns), join(values))
+	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s) RETURNING %s", q.Table, join(columns), join(values), idName)
 }
 
 // Update returns the query to update a record. Update won't update neither the
 // id nor the created_at column.
 func (q *QueryBuilder) Update() string {
 	var v []string
+	var idName = q.idColumn()
 	pos := 1
 	for _, name := range q.Columns {
-		if name != idColumn && name != createdAtColumn {
-			v = append(v, name+" = $"+strconv.Itoa(pos))
+		if name != idName && name != createdAtColumn {
+			v = append(v, name+" = "+q.bind(pos))
 			pos++
 		}
 	}
-	return fmt.Sprintf("UPDATE %s SET %s WHERE id = $%d", q.Table, join(v), pos)
+	return fmt.Sprintf("UPDATE %s SET %s WHERE %s = %s", q.Table, join(v), q.idColumn(), q.bind(pos))
 }
 
 // NamedUpdate returns the query to update a record using named values. Update
 // won't update neither the id nor the created_at column.
 func (q *QueryBuilder) NamedUpdate() string {
 	var values []string
+	var idName = q.idColumn()
 	for _, name := range q.Columns {
-		if name != idColumn && name != createdAtColumn {
+		if name != idName && name != createdAtColumn {
 			values = append(values, name+" = :"+name)
 		}
 	}
-	return fmt.Sprintf("UPDATE %s SET %s WHERE id = :id", q.Table, join(values))
+	return fmt.Sprintf("UPDATE %s SET %s WHERE %s = :%s", q.Table, join(values), q.idColumn(), idName)
 }
 
 // Delete returns the query to mark a record as deleted.
 func (q *QueryBuilder) Delete() string {
-	return fmt.Sprintf("UPDATE %s SET deleted_at = $1 WHERE id = $2", q.Table)
+	return fmt.Sprintf("UPDATE %s SET deleted_at = %s WHERE %s = %s", q.Table, q.bind(1), q.idColumn(), q.bind(2))
 }
 
 // HardDelete returns the query to delete a row by id.
 func (q *QueryBuilder) HardDelete() string {
-	return fmt.Sprintf("DELETE FROM %s WHERE id = $1", q.Table)
+	return fmt.Sprintf("DELETE FROM %s WHERE %s = %s", q.Table, q.idColumn(), q.bind(1))
+}
+
+func (q *QueryBuilder) idColumn() string {
+	if q.PrimaryKey != "" {
+		return q.PrimaryKey
+	}
+	return idColumn
+}
+
+func (q *QueryBuilder) bind(i int) string {
+	switch q.BindType {
+	case QUESTION:
+		return "?"
+	default:
+		return "$" + strconv.Itoa(i)
+	}
 }
 
 func (q *QueryBuilder) columns() string {
@@ -220,7 +283,7 @@ func (q *QueryBuilder) values() string {
 	n := len(q.Columns)
 	c := make([]string, n)
 	for i := 0; i < n; i++ {
-		c[i] = "$" + strconv.Itoa(i+1)
+		c[i] = q.bind(i + 1)
 	}
 	return join(c)
 }

--- a/table.go
+++ b/table.go
@@ -1,6 +1,7 @@
 package qb
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -8,17 +9,47 @@ import (
 )
 
 type table struct {
-	Name    string
-	Columns []string
+	Name       string
+	Columns    []string
+	PrimaryKey string
+}
+
+func isPrimaryKey(s string) bool {
+	return strings.EqualFold(s, "primaryKey") || strings.EqualFold(s, "pkey")
+}
+
+func (t *table) addColumn(name string) error {
+	if parts := strings.SplitN(name, ",", 2); len(parts) == 2 && isPrimaryKey(parts[1]) {
+		if t.PrimaryKey != "" && t.PrimaryKey != parts[0] {
+			return errors.New("table cannot have more than one primary key")
+		}
+		name = strings.TrimSpace(parts[0])
+		t.Columns = append(t.Columns, name)
+		t.PrimaryKey = name
+		return nil
+	}
+
+	t.Columns = append(t.Columns, strings.TrimSpace(name))
+	return nil
+}
+
+func (t *table) addColumnsFromTable(rt table) error {
+	if rt.PrimaryKey != "" {
+		if t.PrimaryKey != "" && t.PrimaryKey != rt.PrimaryKey {
+			return errors.New("table cannot have more than one primary key")
+		}
+		t.PrimaryKey = rt.PrimaryKey
+	}
+	t.Columns = append(t.Columns, rt.Columns...)
+	return nil
 }
 
 func getTagValue(key string, f reflect.StructField) string {
 	s := f.Tag.Get(key)
-	if s == "" || s == "-" {
+	if s == "-" {
 		return ""
 	}
-	parts := strings.SplitN(s, ",", 2)
-	return strings.TrimSpace(parts[0])
+	return s
 }
 
 func getTableName(name string) string {
@@ -47,7 +78,7 @@ func structOf(i any) (reflect.Value, error) {
 	return reflect.Value{}, fmt.Errorf("%T is neither struct nor does it point to one", i)
 }
 
-func fieldColumns(f reflect.StructField, o *options) []string {
+func fieldColumns(f reflect.StructField, o *options) (table, error) {
 	var typ reflect.Type
 	switch f.Type.Kind() {
 	case reflect.Struct:
@@ -55,25 +86,33 @@ func fieldColumns(f reflect.StructField, o *options) []string {
 	case reflect.Ptr:
 		typ = f.Type.Elem()
 		if typ.Kind() != reflect.Struct {
-			return nil
+			return table{}, nil
 		}
 	default:
-		return nil
+		return table{}, nil
 	}
 
-	var columns []string
+	var t table
 	for i, n := 0, typ.NumField(); i < n; i++ {
 		field := typ.Field(i)
 
-		cols := fieldColumns(field, o)
-		columns = append(columns, cols...)
+		// Get the columns in embedded structs
+		rt, err := fieldColumns(field, o)
+		if err != nil {
+			return table{}, err
+		}
+		if err := t.addColumnsFromTable(rt); err != nil {
+			return table{}, err
+		}
 
 		// Get the columns
 		if name := getTagValue(o.columnTag, field); name != "" {
-			columns = append(columns, name)
+			if err := t.addColumn(name); err != nil {
+				return table{}, err
+			}
 		}
 	}
-	return columns
+	return t, nil
 }
 
 func getTable(i any, o *options) (table, error) {
@@ -95,12 +134,19 @@ func getTable(i any, o *options) (table, error) {
 		}
 
 		// Resolve columns recursively
-		cols := fieldColumns(field, o)
-		t.Columns = append(t.Columns, cols...)
+		rt, err := fieldColumns(field, o)
+		if err != nil {
+			return table{}, err
+		}
+		if err := t.addColumnsFromTable(rt); err != nil {
+			return table{}, err
+		}
 
 		// Get the columns
 		if name := getTagValue(o.columnTag, field); name != "" {
-			t.Columns = append(t.Columns, name)
+			if err := t.addColumn(name); err != nil {
+				return table{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit adds support for the bind parameters `?` and `$n`, extending the support for other databases like MySQL and SQLite3.
