### PR TITLE
Remove unnecessary workflow_call trigger from actionci

### DIFF
--- a/.github/workflows/actionci.yml
+++ b/.github/workflows/actionci.yml
@@ -7,7 +7,6 @@ on:
     branches:
     - "main"
   pull_request:
-  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- Remove the `workflow_call:` trigger from the `actionci.yml` caller workflow
- This trigger is only needed on the reusable workflow in `smallstep/workflows`, not on the caller side

🤖 Generated with [Claude Code](https://claude.com/claude-code)